### PR TITLE
Fix most compiler warnings in iked and compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ if(HAVE_DIRENT_H)
 	add_definitions(-DHAVE_DIRENT_H)
 endif()
 
+check_include_files(grp.h HAVE_GRP_H)
+if(HAVE_GRP_H)
+	add_definitions(-DHAVE_GRP_H)
+endif()
+
 check_include_files("sys/socket.h;netinet/ip_ipsp.h" HAVE_IPSP_H)
 if(HAVE_IPSP_H)
 	add_definitions(-DHAVE_IPSP_H)

--- a/iked/config.c
+++ b/iked/config.c
@@ -874,7 +874,8 @@ config_getstatic(struct iked *env, struct imsg *imsg)
 	IMSG_SIZE_CHECK(imsg, &env->sc_static);
 	memcpy(&env->sc_static, imsg->data, sizeof(env->sc_static));
 
-	log_debug("%s: dpd_check_interval %llu", __func__, env->sc_alive_timeout);
+	log_debug("%s: dpd_check_interval %llu", __func__,
+	    (long long unsigned)env->sc_alive_timeout);
 	log_debug("%s: %senforcesingleikesa", __func__,
 	    env->sc_enforcesingleikesa ? "" : "no ");
 	log_debug("%s: %sfragmentation", __func__, env->sc_frag ? "" : "no ");

--- a/iked/dh.c
+++ b/iked/dh.c
@@ -37,34 +37,34 @@
 #include "dh.h"
 #include "iked.h"
 
-int	dh_init(struct group *);
-int	dh_getlen(struct group *);
-int	dh_secretlen(struct group *);
+int	dh_init(struct dh_group *);
+int	dh_getlen(struct dh_group *);
+int	dh_secretlen(struct dh_group *);
 
 /* MODP */
-int	modp_init(struct group *);
-int	modp_getlen(struct group *);
-int	modp_create_exchange(struct group *, uint8_t *);
-int	modp_create_shared(struct group *, uint8_t *, uint8_t *);
+int	modp_init(struct dh_group *);
+int	modp_getlen(struct dh_group *);
+int	modp_create_exchange(struct dh_group *, uint8_t *);
+int	modp_create_shared(struct dh_group *, uint8_t *, uint8_t *);
 
 /* ECP */
-int	ec_init(struct group *);
-int	ec_getlen(struct group *);
-int	ec_secretlen(struct group *);
-int	ec_create_exchange(struct group *, uint8_t *);
-int	ec_create_shared(struct group *, uint8_t *, uint8_t *);
+int	ec_init(struct dh_group *);
+int	ec_getlen(struct dh_group *);
+int	ec_secretlen(struct dh_group *);
+int	ec_create_exchange(struct dh_group *, uint8_t *);
+int	ec_create_shared(struct dh_group *, uint8_t *, uint8_t *);
 
 #define EC_POINT2RAW_FULL	0
 #define EC_POINT2RAW_XONLY	1
-int	ec_point2raw(struct group *, const EC_POINT *, uint8_t *, size_t, int);
+int	ec_point2raw(struct dh_group *, const EC_POINT *, uint8_t *, size_t, int);
 EC_POINT *
-	ec_raw2point(struct group *, uint8_t *, size_t);
+	ec_raw2point(struct dh_group *, uint8_t *, size_t);
 
 /* curve25519 */
-int	ec25519_init(struct group *);
-int	ec25519_getlen(struct group *);
-int	ec25519_create_exchange(struct group *, uint8_t *);
-int	ec25519_create_shared(struct group *, uint8_t *, uint8_t *);
+int	ec25519_init(struct dh_group *);
+int	ec25519_getlen(struct dh_group *);
+int	ec25519_create_exchange(struct dh_group *, uint8_t *);
+int	ec25519_create_shared(struct dh_group *, uint8_t *, uint8_t *);
 
 #define CURVE25519_SIZE 32	/* 256 bits */
 struct curve25519_key {
@@ -265,7 +265,7 @@ group_init(void)
 }
 
 void
-group_free(struct group *group)
+group_free(struct dh_group *group)
 {
 	if (group == NULL)
 		return;
@@ -278,11 +278,11 @@ group_free(struct group *group)
 	free(group);
 }
 
-struct group *
+struct dh_group *
 group_get(uint32_t id)
 {
 	const struct group_id	*p;
-	struct group		*group;
+	struct dh_group		*group;
 
 	if ((p = group_getid(id)) == NULL)
 		return (NULL);
@@ -343,19 +343,19 @@ group_getid(uint32_t id)
 }
 
 int
-dh_init(struct group *group)
+dh_init(struct dh_group *group)
 {
 	return (group->init(group));
 }
 
 int
-dh_getlen(struct group *group)
+dh_getlen(struct dh_group *group)
 {
 	return (group->getlen(group));
 }
 
 int
-dh_secretlen(struct group *group)
+dh_secretlen(struct dh_group *group)
 {
 	if (group->secretlen)
 		return (group->secretlen(group));
@@ -364,7 +364,7 @@ dh_secretlen(struct group *group)
 }
 
 int
-dh_create_exchange(struct group *group, struct ibuf **bufp, struct ibuf *iexchange)
+dh_create_exchange(struct dh_group *group, struct ibuf **bufp, struct ibuf *iexchange)
 {
 	struct ibuf *buf;
 
@@ -377,7 +377,7 @@ dh_create_exchange(struct group *group, struct ibuf **bufp, struct ibuf *iexchan
 }
 
 int
-dh_create_shared(struct group *group, struct ibuf **secretp, struct ibuf *exchange)
+dh_create_shared(struct dh_group *group, struct ibuf **secretp, struct ibuf *exchange)
 {
 	struct ibuf *buf;
 
@@ -393,7 +393,7 @@ dh_create_shared(struct group *group, struct ibuf **secretp, struct ibuf *exchan
 }
 
 int
-modp_init(struct group *group)
+modp_init(struct dh_group *group)
 {
 	BIGNUM	*g = NULL, *p = NULL;
 	DH	*dh;
@@ -418,7 +418,7 @@ modp_init(struct group *group)
 }
 
 int
-modp_getlen(struct group *group)
+modp_getlen(struct dh_group *group)
 {
 	if (group->spec == NULL)
 		return (0);
@@ -426,7 +426,7 @@ modp_getlen(struct group *group)
 }
 
 int
-modp_create_exchange(struct group *group, uint8_t *buf)
+modp_create_exchange(struct dh_group *group, uint8_t *buf)
 {
 	const BIGNUM	*pub;
 	DH		*dh = group->dh;
@@ -451,7 +451,7 @@ modp_create_exchange(struct group *group, uint8_t *buf)
 }
 
 int
-modp_create_shared(struct group *group, uint8_t *secret, uint8_t *exchange)
+modp_create_shared(struct dh_group *group, uint8_t *secret, uint8_t *exchange)
 {
 	BIGNUM	*ex;
 	int	 len, ret;
@@ -476,7 +476,7 @@ modp_create_shared(struct group *group, uint8_t *secret, uint8_t *exchange)
 }
 
 int
-ec_init(struct group *group)
+ec_init(struct dh_group *group)
 {
 	if ((group->ec = EC_KEY_new_by_curve_name(group->spec->nid)) == NULL)
 		return (-1);
@@ -490,7 +490,7 @@ ec_init(struct group *group)
 }
 
 int
-ec_getlen(struct group *group)
+ec_getlen(struct dh_group *group)
 {
 	if (group->spec == NULL)
 		return (0);
@@ -507,13 +507,13 @@ ec_getlen(struct group *group)
  * See also RFC 5903, 9. Changes from RFC 4753.
  */
 int
-ec_secretlen(struct group *group)
+ec_secretlen(struct dh_group *group)
 {
 	return (ec_getlen(group) / 2);
 }
 
 int
-ec_create_exchange(struct group *group, uint8_t *buf)
+ec_create_exchange(struct dh_group *group, uint8_t *buf)
 {
 	size_t	 len;
 
@@ -525,7 +525,7 @@ ec_create_exchange(struct group *group, uint8_t *buf)
 }
 
 int
-ec_create_shared(struct group *group, uint8_t *secret, uint8_t *exchange)
+ec_create_shared(struct dh_group *group, uint8_t *secret, uint8_t *exchange)
 {
 	const EC_GROUP	*ecgroup = NULL;
 	const BIGNUM	*privkey;
@@ -573,7 +573,7 @@ ec_create_shared(struct group *group, uint8_t *secret, uint8_t *exchange)
 }
 
 int
-ec_point2raw(struct group *group, const EC_POINT *point,
+ec_point2raw(struct dh_group *group, const EC_POINT *point,
     uint8_t *buf, size_t len, int mode)
 {
 	const EC_GROUP	*ecgroup = NULL;
@@ -645,7 +645,7 @@ ec_point2raw(struct group *group, const EC_POINT *point,
 }
 
 EC_POINT *
-ec_raw2point(struct group *group, uint8_t *buf, size_t len)
+ec_raw2point(struct dh_group *group, uint8_t *buf, size_t len)
 {
 	const EC_GROUP	*ecgroup = NULL;
 	EC_POINT	*point = NULL;
@@ -703,7 +703,7 @@ ec_raw2point(struct group *group, uint8_t *buf, size_t len)
 }
 
 int
-ec25519_init(struct group *group)
+ec25519_init(struct dh_group *group)
 {
 	static const uint8_t	 basepoint[CURVE25519_SIZE] = { 9 };
 	struct curve25519_key	*curve25519;
@@ -721,7 +721,7 @@ ec25519_init(struct group *group)
 }
 
 int
-ec25519_getlen(struct group *group)
+ec25519_getlen(struct dh_group *group)
 {
 	if (group->spec == NULL)
 		return (0);
@@ -729,7 +729,7 @@ ec25519_getlen(struct group *group)
 }
 
 int
-ec25519_create_exchange(struct group *group, uint8_t *buf)
+ec25519_create_exchange(struct dh_group *group, uint8_t *buf)
 {
 	struct curve25519_key	*curve25519 = group->curve25519;
 
@@ -738,7 +738,7 @@ ec25519_create_exchange(struct group *group, uint8_t *buf)
 }
 
 int
-ec25519_create_shared(struct group *group, uint8_t *shared, uint8_t *public)
+ec25519_create_shared(struct dh_group *group, uint8_t *shared, uint8_t *public)
 {
 	struct curve25519_key	*curve25519 = group->curve25519;
 

--- a/iked/dh.h
+++ b/iked/dh.h
@@ -34,7 +34,7 @@ struct group_id {
 	int		 nid;
 };
 
-struct group {
+struct dh_group {
 	int		 id;
 	const struct group_id
 			*spec;
@@ -43,22 +43,22 @@ struct group {
 	void		*ec;
 	void		*curve25519;
 
-	int		(*init)(struct group *);
-	int		(*getlen)(struct group *);
-	int		(*secretlen)(struct group *);
-	int		(*exchange)(struct group *, uint8_t *);
-	int		(*shared)(struct group *, uint8_t *, uint8_t *);
+	int		(*init)(struct dh_group *);
+	int		(*getlen)(struct dh_group *);
+	int		(*secretlen)(struct dh_group *);
+	int		(*exchange)(struct dh_group *, uint8_t *);
+	int		(*shared)(struct dh_group *, uint8_t *, uint8_t *);
 };
 
 #define DH_MAXSZ	1024	/* 8192 bits */
 
 void		 group_init(void);
-void		 group_free(struct group *);
-struct group	*group_get(uint32_t);
+void		 group_free(struct dh_group *);
+struct dh_group	*group_get(uint32_t);
 const struct group_id
 		*group_getid(uint32_t);
 
-int		 dh_create_exchange(struct group *, struct ibuf **, struct ibuf *);
-int		 dh_create_shared(struct group *, struct ibuf **, struct ibuf *);
+int		 dh_create_exchange(struct dh_group *, struct ibuf **, struct ibuf *);
+int		 dh_create_shared(struct dh_group *, struct ibuf **, struct ibuf *);
 
 #endif /* DH_GROUP_H */

--- a/iked/iked.h
+++ b/iked/iked.h
@@ -372,7 +372,7 @@ struct iked_kex {
 	struct ibuf			*kex_inonce;	/* Ni */
 	struct ibuf			*kex_rnonce;	/* Nr */
 
-	struct group			*kex_dhgroup;	/* DH group */
+	struct dh_group			*kex_dhgroup;	/* DH group */
 	struct ibuf			*kex_dhiexchange;
 	struct ibuf			*kex_dhrexchange;
 	struct ibuf			*kex_dhpeer;	/* pointer to i or r */

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -1237,7 +1237,7 @@ ikev2_init_ike_sa_peer(struct iked *env, struct iked_policy *pol,
 	struct ikev2_notify		*n;
 	struct iked_sa			*sa = NULL;
 	struct ibuf			*buf, *cookie = NULL;
-	struct group			*group;
+	struct dh_group			*group;
 	ssize_t				 len;
 	int				 ret = -1;
 	struct iked_socket		*sock;
@@ -3057,7 +3057,7 @@ ikev2_resp_ike_sa_init(struct iked *env, struct iked_message *msg)
 	struct ikev2_keyexchange	*ke;
 	struct iked_sa			*sa = msg->msg_sa;
 	struct ibuf			*buf;
-	struct group			*group;
+	struct dh_group			*group;
 	ssize_t				 len;
 	int				 ret = -1;
 
@@ -3773,7 +3773,7 @@ ikev2_send_create_child_sa(struct iked *env, struct iked_sa *sa,
 	struct ikev2_notify		*n;
 	struct ikev2_payload		*pld = NULL;
 	struct ikev2_keyexchange	*ke;
-	struct group			*group;
+	struct dh_group			*group;
 	struct ibuf			*e = NULL, *nonce = NULL;
 	uint8_t				*ptr;
 	uint8_t				 firstpayload;
@@ -3941,7 +3941,7 @@ ikev2_ike_sa_rekey(struct iked *env, void *arg)
 	struct iked_sa			*nsa = NULL;
 	struct ikev2_payload		*pld = NULL;
 	struct ikev2_keyexchange	*ke;
-	struct group			*group;
+	struct dh_group			*group;
 	struct ibuf			*e = NULL, *nonce = NULL;
 	ssize_t				 len = 0;
 	int				 ret = -1;
@@ -5317,7 +5317,7 @@ ikev2_sa_keys(struct iked *env, struct iked_sa *sa, struct ibuf *key)
 {
 	struct iked_hash	*prf, *integr;
 	struct iked_cipher	*encr;
-	struct group		*group;
+	struct dh_group		*group;
 	struct ibuf		*ninr, *dhsecret, *skeyseed, *s, *t;
 	size_t			 nonceminlen, ilen, rlen, tmplen;
 	uint64_t		 ispi, rspi;
@@ -5767,7 +5767,7 @@ ikev2_childsa_negotiate(struct iked *env, struct iked_sa *sa,
 	struct iked_flow	*flow, *saflow, *flowa, *flowb;
 	struct iked_ipcomp	*ic;
 	struct ibuf		*keymat = NULL, *seed = NULL, *dhsecret = NULL;
-	struct group		*group;
+	struct dh_group		*group;
 	uint32_t		 spi = 0;
 	unsigned int		 i;
 	size_t			 ilen = 0;

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -4833,7 +4833,8 @@ ikev2_ike_sa_alive(struct iked *env, void *arg)
 		log_debug("%s: %s CHILD SA spi %s last used %llu second(s) ago",
 		    __func__,
 		    csa->csa_dir == IPSP_DIRECTION_IN ? "incoming" : "outgoing",
-		    print_spi(csa->csa_spi.spi, csa->csa_spi.spi_size), diff);
+		    print_spi(csa->csa_spi.spi, csa->csa_spi.spi_size),
+		    (long long unsigned)diff);
 		if (diff < env->sc_alive_timeout) {
 			if (csa->csa_dir == IPSP_DIRECTION_IN) {
 				foundin = 1;
@@ -4850,7 +4851,8 @@ ikev2_ike_sa_alive(struct iked *env, void *arg)
 		log_debug("%s: IKE SA %p ispi %s rspi %s last received %llu"
 		    " second(s) ago", __func__, sa,
 		    print_spi(sa->sa_hdr.sh_ispi, 8),
-		    print_spi(sa->sa_hdr.sh_rspi, 8), diff);
+		    print_spi(sa->sa_hdr.sh_rspi, 8),
+		    (long long unsigned)diff);
 	}
 
 	/*

--- a/iked/parse.y
+++ b/iked/parse.y
@@ -818,7 +818,7 @@ host_spec	: STRING			{
 		| STRING '/' NUMBER		{
 			char	*buf;
 
-			if (asprintf(&buf, "%s/%lld", $1, $3) == -1)
+			if (asprintf(&buf, "%s/%lld", $1, (long long)$3) == -1)
 				err(1, "host: asprintf");
 			free($1);
 			if (($$ = host(buf)) == NULL)	{
@@ -1099,7 +1099,8 @@ byte_spec	: NUMBER			{
 			uint64_t	 bytes = 0;
 			char		 unit = 0;
 
-			if (sscanf($1, "%llu%c", &bytes, &unit) != 2) {
+			if (sscanf($1, "%llu%c", (long long unsigned *)&bytes,
+			    &unit) != 2) {
 				yyerror("invalid byte specification: %s", $1);
 				YYERROR;
 			}
@@ -1129,7 +1130,8 @@ time_spec	: NUMBER			{
 			uint64_t	 seconds = 0;
 			char		 unit = 0;
 
-			if (sscanf($1, "%llu%c", &seconds, &unit) != 2) {
+			if (sscanf($1, "%llu%c", (long long unsigned *)&seconds,
+			    &unit) != 2) {
 				yyerror("invalid time specification: %s", $1);
 				YYERROR;
 			}
@@ -2608,7 +2610,8 @@ print_policy(struct iked_policy *pol)
 		print_verbose(" ikelifetime %u", pol->pol_rekey);
 
 	print_verbose(" lifetime %llu bytes %llu",
-	    pol->pol_lifetime.lt_seconds, pol->pol_lifetime.lt_bytes);
+	    (long long unsigned)pol->pol_lifetime.lt_seconds,
+	    (long long unsigned)pol->pol_lifetime.lt_bytes);
 
 	switch (pol->pol_auth.auth_method) {
 	case IKEV2_AUTH_NONE:

--- a/iked/pfkey.c
+++ b/iked/pfkey.c
@@ -692,6 +692,7 @@ pfkey_sa(int sd, uint8_t satype, uint8_t action, struct iked_childsa *sa)
 #endif
 #ifdef SADB_X_EXT_TAP
 	struct sadb_x_tap	 sa_tap;
+	int			 dotap = 0;
 #endif
 #ifdef SADB_X_EXT_RDOMAIN
 	struct sadb_x_rdomain	 sa_rdomain;
@@ -707,7 +708,7 @@ pfkey_sa(int sd, uint8_t satype, uint8_t action, struct iked_childsa *sa)
 	struct iovec		 iov[IOV_CNT];
 	uint32_t		 jitter;
 	int			 iov_cnt;
-	int			 ret, dotap = 0;
+	int			 ret;
 
 	sa_srcid = sa_dstid = NULL;
 
@@ -1150,19 +1151,22 @@ pfkey_sa(int sd, uint8_t satype, uint8_t action, struct iked_childsa *sa)
 int
 pfkey_sa_lookup(int sd, struct iked_childsa *sa, uint64_t *last_used)
 {
-	struct iked_policy	*pol = sa->csa_ikesa->sa_policy;
 	struct sadb_msg		*msg, smsg;
 	struct sadb_address	 sa_src, sa_dst;
 	struct sadb_sa		 sadb;
 #ifdef SADB_X_EXT_RDOMAIN
+	struct iked_policy	*pol = sa->csa_ikesa->sa_policy;
 	struct sadb_x_rdomain	 sa_rdomain;
+	int rdomain;
 #endif
+#ifdef SADB_X_EXT_LIFETIME_LASTUSE
 	struct sadb_lifetime	*sa_life;
+#endif
 	struct sockaddr_storage	 ssrc, sdst;
 	struct iovec		 iov[IOV_CNT];
 	uint8_t			*data;
 	ssize_t			 n;
-	int			 iov_cnt, ret = -1, rdomain;
+	int			 iov_cnt, ret = -1;
 	uint8_t			 satype;
 
 	if (last_used)

--- a/iked/proc.c
+++ b/iked/proc.c
@@ -32,6 +32,10 @@
 #include <event.h>
 #include <imsg.h>
 
+#if HAVE_GRP_H
+#include <grp.h>
+#endif
+
 #include "iked.h"
 
 enum privsep_procid privsep_process;

--- a/iked/util.c
+++ b/iked/util.c
@@ -524,10 +524,10 @@ print_spi(uint64_t spi, int size)
 		snprintf(ptr, 32, "0x%08x", (uint32_t)spi);
 		break;
 	case 8:
-		snprintf(ptr, 32, "0x%016llx", spi);
+		snprintf(ptr, 32, "0x%016llx", (long long unsigned)spi);
 		break;
 	default:
-		snprintf(ptr, 32, "%llu", spi);
+		snprintf(ptr, 32, "%llu", (long long unsigned)spi);
 		break;
 	}
 

--- a/iked/util.c
+++ b/iked/util.c
@@ -427,7 +427,7 @@ recvfromto(int s, void *buf, size_t len, int flags, struct sockaddr *from,
 	struct iovec		 iov;
 	struct msghdr		 msg;
 	struct cmsghdr		*cmsg;
-#if defined(IP_RECVDSTADDR) || defined(IP_RECVORIGDSTADDR)
+#if defined(IP_RECVDSTADDR)
 	struct sockaddr_in	*in;
 #endif
 #ifdef IPV6_PKTINFO

--- a/regress/parser/common.c
+++ b/regress/parser/common.c
@@ -32,7 +32,7 @@ int	 sa_stateok(const struct iked_sa *, int);
 void	 sa_state(struct iked *, struct iked_sa *, int);
 void	 ikev2_disable_rekeying(struct iked *, struct iked_sa *);
 void	 ikev2_init_ike_sa(struct iked *, void *);
-struct group *
+struct dh_group *
 	 group_get(u_int32_t);
 void	 timer_set(struct iked *, struct iked_timer *,
 	     void (*)(struct iked *, void *), void *);


### PR DESCRIPTION
- Fix format string warnings
- include "grp.h" on linux fro setgroups()
- rename dh.h `struct group` to `struct dh_group` to prevent name conflict
- `#ifdef` around variables in pfkey to prevent unused variable warnings