### PR TITLE
Fix OpenSSL 1.1 API errors

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,6 +48,11 @@ jobs:
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
+    - name: Test
+      working-directory: ${{github.workspace}}/build/regress/dh
+      shell: bash
+      run: ./dhtest
+
   macos:
     strategy:
       matrix:
@@ -69,3 +74,8 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: cmake --build . --config $BUILD_TYPE
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build/regress/dh
+      shell: bash
+      run: ./dhtest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,5 +316,6 @@ endif()
 
 add_subdirectory(iked)
 add_subdirectory(ikectl)
+add_subdirectory(regress/dh)
 add_subdirectory(regress/parser)
 add_subdirectory(regress/test_helper)

--- a/iked/ca.c
+++ b/iked/ca.c
@@ -565,6 +565,8 @@ ca_getreq(struct iked *env, struct imsg *imsg)
 			if (subj == NULL)
 				return (-1);
 			subj_name = X509_NAME_oneline(subj, NULL, 0);
+			if (subj_name == NULL)
+				return (-1);
 			log_debug("%s: found CA %s", __func__, subj_name);
 
 			if ((cert = ca_by_issuer(store->ca_certs,
@@ -615,6 +617,8 @@ ca_getreq(struct iked *env, struct imsg *imsg)
 		if (subj == NULL)
 			return (-1);
 		subj_name = X509_NAME_oneline(subj, NULL, 0);
+		if (subj_name == NULL)
+			return (-1);
 		log_debug("%s: found local certificate %s", __func__,
 		    subj_name);
 
@@ -788,6 +792,8 @@ ca_reload(struct iked *env)
 		if (subj == NULL)
 			return (-1);
 		subj_name = X509_NAME_oneline(subj, NULL, 0);
+		if (subj_name == NULL)
+			return (-1);
 		log_debug("%s: %s", __func__, subj_name);
 
 		if (ibuf_add(env->sc_certreq, md, len) != 0) {
@@ -1597,6 +1603,8 @@ ca_validate_cert(struct iked *env, struct iked_static_id *id,
 		if (subj == NULL)
 			goto err;
 		subj_name = X509_NAME_oneline(subj, NULL, 0);
+		if (subj_name == NULL)
+			goto err;
 		log_debug("%s: %s %.100s", __func__, subj_name, errstr);
 	}
  err:

--- a/iked/crypto.c
+++ b/iked/crypto.c
@@ -1159,13 +1159,13 @@ _dsa_verify_prepare(struct iked_dsa *dsa, uint8_t **sigp, size_t *lenp,
 			goto done;
 		bnlen = (*lenp)/2;
 		/* sigp points to concatenation: r|s */
-		if ((obj = ECDSA_SIG_new()) == NULL)
-			goto done;
-		if ((r = BN_bin2bn(*sigp, bnlen, NULL)) == NULL ||
+		if ((obj = ECDSA_SIG_new()) == NULL ||
+		    (r = BN_bin2bn(*sigp, bnlen, NULL)) == NULL ||
 		    (s = BN_bin2bn(*sigp+bnlen, bnlen, NULL)) == NULL ||
+		    ECDSA_SIG_set0(obj, r, s) == 0 ||
 		    (len = i2d_ECDSA_SIG(obj, &ptr)) == 0)
 			goto done;
-		ECDSA_SIG_set0(obj, r, s);
+		r = s = NULL;
 		*lenp = len;
 		*sigp = ptr;
 		*freemep = ptr;

--- a/iked/dh.c
+++ b/iked/dh.c
@@ -403,10 +403,11 @@ modp_init(struct dh_group *group)
 		return (-1);
 
 	if (!BN_hex2bn(&p, group->spec->prime) ||
-	    !BN_hex2bn(&g, group->spec->generator))
+	    !BN_hex2bn(&g, group->spec->generator) ||
+	    DH_set0_pqg(dh, p, NULL, g) == 0)
 		goto done;
 
-	DH_set0_pqg(dh, p, NULL, g);
+	p = g = 0;
 	group->dh = dh;
 
 	ret = 0;

--- a/regress/dh/CMakeLists.txt
+++ b/regress/dh/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2020-2021 Tobias Heider <tobhe@openbsd.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set(SRCS)
+list(APPEND SRCS
+	dhtest.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../iked/dh.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../iked/smult_curve25519_ref.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../iked/imsg_util.c
+)
+
+if(TARGET compat)
+	list(APPEND SRCS $<TARGET_OBJECTS:compat>)
+endif()
+
+add_executable(dhtest ${SRCS})
+
+target_include_directories(dhtest
+	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../iked
+	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../iked/compat
+)
+
+target_link_libraries(dhtest
+	PRIVATE util crypto
+)
+
+target_compile_options(dhtest PRIVATE ${CFLAGS})

--- a/regress/dh/dhtest.c
+++ b/regress/dh/dhtest.c
@@ -56,7 +56,7 @@ main(void)
 	struct ibuf *buf, *buf2;
 	struct ibuf *sec, *sec2;
 	uint8_t *raw, *raw2;
-	struct group *group, *group2;
+	struct dh_group *group, *group2;
 	const char *name[] = { "MODP", "ECP", "CURVE25519" };
 
 	group_init();


### PR DESCRIPTION
- Fix errors introduced with switch to OpenSSL 1.1 API
- build Diffie-Hellman test in `regress/dhtest` (which found the bug)
- run `dhtest` with CI to catch future errors in dh.c