### PR TITLE
Fix compilation with -DOPENSSL_NO_EC2M

### DIFF
--- a/iked/dh.c
+++ b/iked/dh.c
@@ -609,16 +609,9 @@ ec_point2raw(struct dh_group *group, const EC_POINT *point,
 	if ((ecgroup = EC_KEY_get0_group(group->ec)) == NULL)
 		goto done;
 
-	if (EC_METHOD_get_field_type(EC_GROUP_method_of(ecgroup)) ==
-	    NID_X9_62_prime_field) {
-		if (!EC_POINT_get_affine_coordinates_GFp(ecgroup,
-		    point, x, y, bnctx))
-			goto done;
-	} else {
-		if (!EC_POINT_get_affine_coordinates_GF2m(ecgroup,
-		    point, x, y, bnctx))
-			goto done;
-	}
+	if (!EC_POINT_get_affine_coordinates_GFp(ecgroup,
+	    point, x, y, bnctx))
+		goto done;
 
 	xoff = xlen - BN_num_bytes(x);
 	bzero(buf, xoff);
@@ -677,16 +670,9 @@ ec_raw2point(struct dh_group *group, uint8_t *buf, size_t len)
 	if ((point = EC_POINT_new(ecgroup)) == NULL)
 		goto done;
 
-	if (EC_METHOD_get_field_type(EC_GROUP_method_of(ecgroup)) ==
-	    NID_X9_62_prime_field) {
-		if (!EC_POINT_set_affine_coordinates_GFp(ecgroup,
-		    point, x, y, bnctx))
-			goto done;
-	} else {
-		if (!EC_POINT_set_affine_coordinates_GF2m(ecgroup,
-		    point, x, y, bnctx))
-			goto done;
-	}
+	if (!EC_POINT_set_affine_coordinates_GFp(ecgroup,
+	    point, x, y, bnctx))
+		goto done;
 
 	ret = 0;
  done:


### PR DESCRIPTION
`EC_POINT_get_affine_coordinates_GFp()` and `EC_POINT_get_affine_coordinates_GFm2()`
are the same thing, but the `_GFm2()` variant can be disabled with `-DOPENSSL_NO_EC2M`.
Always use `_GFp()` to fix compilation with `NO_ECM` OpenSSL builds.

Should fix #31 