### PR TITLE
Fix remaining Linux bugs

### DIFF
--- a/iked/iked.c
+++ b/iked/iked.c
@@ -240,17 +240,17 @@ parent_configure(struct iked *env)
 
 	/* see comment on config_setsocket() */
 	if (env->sc_nattmode != NATT_FORCE)
-		config_setsocket(env, &ss, htons(IKED_IKE_PORT), PROC_IKEV2);
+		config_setsocket(env, &ss, htons(IKED_IKE_PORT), PROC_IKEV2, 0);
 	if (env->sc_nattmode != NATT_DISABLE)
-		config_setsocket(env, &ss, htons(env->sc_nattport), PROC_IKEV2);
+		config_setsocket(env, &ss, htons(env->sc_nattport), PROC_IKEV2, 1);
 
 	bzero(&ss, sizeof(ss));
 	ss.ss_family = AF_INET6;
 
 	if (env->sc_nattmode != NATT_FORCE)
-		config_setsocket(env, &ss, htons(IKED_IKE_PORT), PROC_IKEV2);
+		config_setsocket(env, &ss, htons(IKED_IKE_PORT), PROC_IKEV2, 0);
 	if (env->sc_nattmode != NATT_DISABLE)
-		config_setsocket(env, &ss, htons(env->sc_nattport), PROC_IKEV2);
+		config_setsocket(env, &ss, htons(env->sc_nattport), PROC_IKEV2, 1);
 
 	/*
 	 * pledge in the parent process:

--- a/iked/iked.h
+++ b/iked/iked.h
@@ -830,7 +830,7 @@ int	 config_setflow(struct iked *, struct iked_policy *,
 	    enum privsep_procid);
 int	 config_getflow(struct iked *, struct imsg *);
 int	 config_setsocket(struct iked *, struct sockaddr_storage *, in_port_t,
-	    enum privsep_procid);
+	    enum privsep_procid, int);
 int	 config_getsocket(struct iked *env, struct imsg *,
 	    void (*cb)(int, short, void *));
 int	 config_setpfkey(struct iked *, enum privsep_procid);

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -5979,6 +5979,29 @@ ikev2_childsa_negotiate(struct iked *env, struct iked_sa *sa,
 			if (ikev2_cp_fixflow(sa, flow, flowb) == -1)
 				continue;
 
+#if defined(HAVE_LINUX_IPSEC_H)
+			struct iked_flow	*flowc;
+
+			if ((flowc = calloc(1, sizeof(*flowc))) == NULL) {
+				log_debug("%s: failed to get flow", __func__);
+				flow_free(flowa);
+				flow_free(flowb);
+				goto done;
+			}
+
+			memcpy(flowc, flowa, sizeof(*flow));
+
+			/* Linux is special and requires a FWD flow */
+			flowc->flow_dir = IPSEC_DIR_FWD;
+			memcpy(&flowc->flow_src, &flow->flow_dst,
+			    sizeof(flow->flow_dst));
+			memcpy(&flowc->flow_dst, &flow->flow_src,
+			    sizeof(flow->flow_src));
+			if (ikev2_cp_fixflow(sa, flow, flowc) == -1)
+				continue;
+
+			TAILQ_INSERT_TAIL(&sa->sa_flows, flowc, flow_entry);
+#endif
 			TAILQ_INSERT_TAIL(&sa->sa_flows, flowa, flow_entry);
 			TAILQ_INSERT_TAIL(&sa->sa_flows, flowb, flow_entry);
 		}

--- a/iked/pfkey.c
+++ b/iked/pfkey.c
@@ -529,12 +529,12 @@ pfkey_flow(int sd, uint8_t satype, uint8_t action, struct iked_flow *flow)
 	if (flow->flow_local == NULL) {
 		slocal.ss_family = flow->flow_src.addr_af;
 		speer.ss_family = flow->flow_dst.addr_af;
-	} else if (flow->flow_dir == IPSEC_DIR_INBOUND) {
-		memcpy(&speer, &flow->flow_local->addr, sizeof(slocal));
-		memcpy(&slocal, &flow->flow_peer->addr, sizeof(speer));
-	} else {
+	} else if (flow->flow_dir == IPSEC_DIR_OUTBOUND) {
 		memcpy(&slocal, &flow->flow_local->addr, sizeof(slocal));
 		memcpy(&speer, &flow->flow_peer->addr, sizeof(speer));
+	} else {
+		memcpy(&speer, &flow->flow_local->addr, sizeof(slocal));
+		memcpy(&slocal, &flow->flow_peer->addr, sizeof(speer));
 	}
 	socket_af((struct sockaddr *)&slocal, 0);
 	socket_af((struct sockaddr *)&speer, 0);
@@ -575,8 +575,8 @@ pfkey_flow(int sd, uint8_t satype, uint8_t action, struct iked_flow *flow)
 	sa_ipsec.sadb_x_ipsecrequest_mode = IPSEC_MODE_TUNNEL;
 	/* XXX: Always use IPSEC_LEVEL_REQUIRE */
 	sa_ipsec.sadb_x_ipsecrequest_level =
-	    flow->flow_dir == IPSEC_DIR_INBOUND ?
-	    IPSEC_LEVEL_USE : IPSEC_LEVEL_REQUIRE;
+	    flow->flow_dir == IPSEC_DIR_OUTBOUND ?
+	    IPSEC_LEVEL_REQUIRE : IPSEC_LEVEL_USE ;
 	sa_ipsec.sadb_x_ipsecrequest_len = sizeof(sa_ipsec);
 	sa_ipsec.sadb_x_ipsecrequest_len += SS_LEN(slocal) + SS_LEN(speer);
 	padlen = ROUNDUP(sa_ipsec.sadb_x_ipsecrequest_len) -


### PR DESCRIPTION
- When using udpencap, set the `ESPINUDP` sockopt on both listen and send sock. Unbreaks udpencap as responder.
- On Linux, add a flow of type `IPSEC_DIR_FWD` to allow forwarding of IPsec traffic.