### PR TITLE
usage() tells about ikectl(8)

### DIFF
--- a/ikectl/ikectl.c
+++ b/ikectl/ikectl.c
@@ -73,7 +73,8 @@ usage(void)
 {
 	extern char *__progname;
 
-	fprintf(stderr, "usage: %s [-q] [-s socket] command [arg ...]\n",
+	fprintf(stderr, "usage: %s [-q] [-s socket] command [arg ...]\n"
+		"See ikectl(8) for more info\n",
 	    __progname);
 	exit(1);
 }
@@ -166,6 +167,9 @@ main(int argc, char *argv[])
 	int			 v = 0;
 	int			 quiet = 0;
 	const char		*sock = IKED_SOCKET;
+
+	if (argv[1] == NULL)
+		usage();
 
 	while ((ch = getopt(argc, argv, "qs:")) != -1) {
 		switch (ch) {


### PR DESCRIPTION
By running `ikectl(8)` without any parameters it shows list of available commands, but not how to use the `ikectl(8)`.
* We see usage() if no arguments are provided (argv[1] == NULL)
* usage() tells about `ikectl(8)` (where user can read about all available args/parameters)