### PR TITLE
libfuzzer: fix false-positive memory leak in ikev2_msg

### DIFF
--- a/regress/parser-libfuzzer/run_test.sh
+++ b/regress/parser-libfuzzer/run_test.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
 
-# script to run the parser-fuzzer with the right options
+# script to run the parser-fuzzer for 5 minutes with the right options
 
 # ASAN-option to help finding the source of memory leaks
-export ASAN_OPTIONS=fast_unwind_on_malloc=0:detect_leaks=0
+export ASAN_OPTIONS=fast_unwind_on_malloc=0
 
-$(dirname "$0")/test_libfuzzer -dict=$(dirname "$0")/fuzz.dict -max_len=8164 -max_total_time=60 $(dirname "$0")/corpus
+$(dirname "$0")/test_libfuzzer -dict=$(dirname "$0")/fuzz.dict -max_len=8164 -max_total_time=300 $(dirname "$0")/corpus
 
-#TODO: remove error_exitcode=0 for github CI
-#maybe the corpus shold be on a persistent storage 
-#total_time is maybe a little bit short
+# maybe it would be a good idea to push the new corpus to another git-repo

--- a/regress/parser-libfuzzer/test_parser_fuzz.c
+++ b/regress/parser-libfuzzer/test_parser_fuzz.c
@@ -112,7 +112,7 @@ LLVMFuzzerTestOneInput(const char *Data, size_t Size)
 
 	fuzzed = ibuf_new(Data, Size);
 	if (fuzzed == NULL){
-                fprintf(stderr, "%s\n", "ERROR: fuzzed == NULL! (hint: fuzz-input too long?)");
+		fprintf(stderr, "%s\n", "ERROR: fuzzed == NULL! (hint: fuzz-input too long?)");
 		return -1;
 	}	
 	
@@ -127,6 +127,7 @@ LLVMFuzzerTestOneInput(const char *Data, size_t Size)
 
 	ikev2_pld_parse(NULL, &hdr, &msg, 0);
 
-	ibuf_free(fuzzed);
+	ikev2_msg_cleanup(NULL, &msg);
+
 	return 0;
 }


### PR DESCRIPTION
add a stub function in common.c to correctly free ikev2-msg in the libfuzzer-test.
this should fix #35 