### PR TITLE
Fix error with simultaneous CHILD SA rekeying

### DIFF
--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -4411,7 +4411,7 @@ ikev2_init_create_child_sa(struct iked *env, struct iked_message *msg)
 		else
 			nr = sa->sa_rnonce;
 		/*
-		 * If the exchange initated by peer has smaller nonce,
+		 * If the exchange initated by us has smaller nonce,
 		 * then we have to delete our SAs.
 		 */
 		if (ikev2_nonce_cmp(nr, ni) < 0) {

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -4405,16 +4405,16 @@ ikev2_init_create_child_sa(struct iked *env, struct iked_message *msg)
 	if (csa && (ni = sa->sa_simult) != NULL) {
 		log_info("%s: resolving simultaneous CHILD SA rekeying",
 		    SPI_SA(sa, __func__));
-		/* set nr to minimum nonce for exchange initiated by peer */
+		/* set nr to minimum nonce for exchange initiated by us */
 		if (ikev2_nonce_cmp(sa->sa_inonce, sa->sa_rnonce) < 0)
 			nr = sa->sa_inonce;
 		else
 			nr = sa->sa_rnonce;
 		/*
-		 * If the exchange initated by us has smaller nonce,
+		 * If the exchange initated by peer has smaller nonce,
 		 * then we have to delete our SAs.
 		 */
-		if (ikev2_nonce_cmp(ni, nr) < 0) {
+		if (ikev2_nonce_cmp(nr, ni) < 0) {
 			ret = ikev2_childsa_delete_proposed(env, sa,
 			    &sa->sa_proposals);
 			goto done;


### PR DESCRIPTION
**Fix error with the comparison of the nonce of the SAs to decide which SA shall be deleted.**
_nr_ is not set to the minimum nonce for exchange initiated by peer, but by us.
_ni_ comes from _sa->sa_simulat_ which is already set to the minimum nonce for exchange initiated by peer.
Thus, by comparing _ni_ with _nr_, the SA that has just been created by us shall be deleted, if _nr<ni_