### PR TITLE
Fix BSD CI to upgrading to newer `macos-12` runner.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -94,7 +94,7 @@ jobs:
       run: ./test_parser
 
   openbsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Bootstrap OpenBSD-latest
       uses: mario-campos/emulate@v1
@@ -115,7 +115,7 @@ jobs:
         cd ../parser; ./test_parser
 
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Bootstrap FreeBSD-latest
       uses: mario-campos/emulate@v1


### PR DESCRIPTION
The `macos-10.15` runners will soon be unavailable. Fortunately, the `macos-12` runners are an easy drop-in replacement.