### PR TITLE
iked: simplify policy refcounting API

### DIFF
--- a/iked/config.c
+++ b/iked/config.c
@@ -221,10 +221,15 @@ config_free_policy(struct iked *env, struct iked_policy *pol)
 	if (pol->pol_flags & IKED_POLICY_REFCNT)
 		goto remove;
 
+	/*
+	 * Remove policy from the sc_policies list, but increment
+	 * refcount for every SA linked for the policy.
+	 */
+	pol->pol_flags |= IKED_POLICY_REFCNT;
+
 	TAILQ_REMOVE(&env->sc_policies, pol, pol_entry);
 
 	TAILQ_FOREACH(sa, &pol->pol_sapeers, sa_peer_entry) {
-		/* Remove from the policy list, but keep for existing SAs */
 		if (sa->sa_policy == pol)
 			policy_ref(env, pol);
 		else

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -269,14 +269,8 @@ ikev2_dispatch_parent(int fd, struct privsep_proc *p, struct imsg *imsg)
 			if (old != sa->sa_policy) {
 				/* Cleanup old policy */
 				TAILQ_REMOVE(&old->pol_sapeers, sa, sa_peer_entry);
-				if (old->pol_flags & IKED_POLICY_REFCNT)
-					policy_unref(env, old);
-
-				if (sa->sa_policy->pol_flags & IKED_POLICY_REFCNT) {
-					log_info("%s: sa %p old pol %p pol_refcnt %d",
-					    __func__, sa, sa->sa_policy, sa->sa_policy->pol_refcnt);
-					policy_ref(env, sa->sa_policy);
-				}
+				policy_unref(env, old);
+				policy_ref(env, sa->sa_policy);
 				TAILQ_INSERT_TAIL(&sa->sa_policy->pol_sapeers, sa, sa_peer_entry);
 			}
 		}
@@ -979,15 +973,13 @@ ikev2_ike_auth_recv(struct iked *env, struct iked_sa *sa,
 			    SPI_SA(sa, __func__));
 			ikev2_send_auth_failed(env, sa);
 			TAILQ_REMOVE(&old->pol_sapeers, sa, sa_peer_entry);
-			if (old->pol_flags & IKED_POLICY_REFCNT)
-				policy_unref(env, old);
+			policy_unref(env, old);
 			return (-1);
 		}
 		if (msg->msg_policy != old) {
 			/* Clean up old policy */
 			TAILQ_REMOVE(&old->pol_sapeers, sa, sa_peer_entry);
-			if (old->pol_flags & IKED_POLICY_REFCNT)
-				policy_unref(env, old);
+			policy_unref(env, old);
 
 			/* Update SA with new policy*/
 			if (sa_new(env, sa->sa_hdr.sh_ispi,
@@ -1019,8 +1011,7 @@ ikev2_ike_auth_recv(struct iked *env, struct iked_sa *sa,
 			log_warnx("%s: policy mismatch", SPI_SA(sa, __func__));
 			ikev2_send_auth_failed(env, sa);
 			TAILQ_REMOVE(&old->pol_sapeers, sa, sa_peer_entry);
-			if (old->pol_flags & IKED_POLICY_REFCNT)
-				policy_unref(env, old);
+			policy_unref(env, old);
 			return (-1);
 		}
 		/* restore */
@@ -5629,10 +5620,8 @@ ikev2_sa_responder(struct iked *env, struct iked_sa *sa, struct iked_sa *osa,
 		TAILQ_REMOVE(&old->pol_sapeers, sa, sa_peer_entry);
 		TAILQ_INSERT_TAIL(&sa->sa_policy->pol_sapeers,
 		    sa, sa_peer_entry);
-		if (old->pol_flags & IKED_POLICY_REFCNT)
-			policy_unref(env, old);
-		if (sa->sa_policy->pol_flags & IKED_POLICY_REFCNT)
-			policy_ref(env, sa->sa_policy);
+		policy_unref(env, old);
+		policy_ref(env, sa->sa_policy);
 	}
 
 	sa_state(env, sa, IKEV2_STATE_SA_INIT);

--- a/iked/policy.c
+++ b/iked/policy.c
@@ -355,8 +355,8 @@ policy_calc_skip_steps(struct iked_policies *policies)
 void
 policy_ref(struct iked *env, struct iked_policy *pol)
 {
-	pol->pol_refcnt++;
-	pol->pol_flags |= IKED_POLICY_REFCNT;
+	if (pol->pol_flags & IKED_POLICY_REFCNT)
+		pol->pol_refcnt++;
 }
 
 void
@@ -521,12 +521,7 @@ sa_new(struct iked *env, uint64_t ispi, uint64_t rspi,
 	if (pol == NULL && sa->sa_policy == NULL)
 		fatalx("%s: sa %p no policy", __func__, sa);
 	else if (sa->sa_policy == NULL) {
-		/* Increment refcount if the policy has refcounting enabled. */
-		if (pol->pol_flags & IKED_POLICY_REFCNT) {
-			log_info("%s: sa %p old pol %p pol_refcnt %d",
-			    __func__, sa, pol, pol->pol_refcnt);
-			policy_ref(env, pol);
-		}
+		policy_ref(env, pol);
 		sa->sa_policy = pol;
 		TAILQ_INSERT_TAIL(&pol->pol_sapeers, sa, sa_peer_entry);
 	} else


### PR DESCRIPTION
- move enabling the policy refcounting from policy_ref() to config_free_policy()
- in config_free_policy() the refcounting is unchanged and each SA linked to the policy will trigger a call to policy_ref() and increase the references as before the change
- this allows unconditional calls to policy_ref() and policy_unref() and the callers no longer have to check if IKED_POLICY_REFCNT is set