### PR TITLE
Use libsystemd to directly send dbus messages

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Install libevent
-      run: sudo apt install libevent-dev
+      run: sudo apt install libevent-dev libsystemd-dev
     
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/iked/CMakeLists.txt
+++ b/iked/CMakeLists.txt
@@ -21,6 +21,7 @@ set(VERSIONED_FILES)
 list(APPEND VERSIONED_FILES iked.c)
 
 set(SRCS)
+set(LIBS)
 
 set(CFLAGS)
 list(APPEND CFLAGS
@@ -118,15 +119,25 @@ else()
 	)
 endif()
 
-if(WITH_APPARMOR)
-	target_link_libraries(iked
-		PRIVATE util event crypto ssl compat iked-shared apparmor
-	)
-else()
-	target_link_libraries(iked
-		PRIVATE util event crypto ssl compat iked-shared
-	)
+list(APPEND LIBS
+	util
+	event
+	crypto
+	ssl
+	compat
+	iked-shared
+)
+
+if (WITH_APPARMOR)
+	list(APPEND LIBS apparmor)
 endif()
+if (HAVE_SYSTEMD)
+	list(APPEND LIBS systemd)
+endif()
+
+target_link_libraries(iked
+	PRIVATE ${LIBS}
+)
 
 add_custom_command(
 	OUTPUT parse.c


### PR DESCRIPTION
Construct our own dbus messages for setting name servers and search domains. This allows us to drop a exec call for resolvectl and should be easier to extend in the future.