### PR TITLE
CMakeLists: fix detection of netinet6/ipsec.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(HAVE_NET_IPSEC_H)
 	add_definitions(-DHAVE_NET_IPSEC_H)
 endif()
 
-check_include_files("netinet6/ipsec.h" HAVE_NETINET6_IPSEC_H)
+check_include_files("sys/types.h;netinet6/ipsec.h" HAVE_NETINET6_IPSEC_H)
 if(HAVE_NETINET6_IPSEC_H)
 	add_definitions(-DHAVE_NETINET6_IPSEC_H)
 endif()


### PR DESCRIPTION
This is what happens currently:
```
    kind: "try_compile-v1"
    backtrace:
      - "/opt/local/share/cmake-3.31/Modules/CheckIncludeFiles.cmake:141 (try_compile)"
      - "CMakeLists.txt:137 (check_include_files)"
    checks:
      - "Looking for include file netinet6/ipsec.h"
    directories:
      source: "/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_net_openiked/openiked/work/build/CMakeFiles/CMakeScratch/TryCompile-wIY0xP"
      binary: "/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_net_openiked/openiked/work/build/CMakeFiles/CMakeScratch/TryCompile-wIY0xP"
    cmakeVariables:
      CMAKE_C_FLAGS: "-pipe -I/opt/local/libexec/openssl3/include -Os -DNDEBUG -I/opt/local/libexec/openssl3/include -isystem/opt/local/include"
      CMAKE_C_FLAGS_DEBUG: "-g"
      CMAKE_EXE_LINKER_FLAGS: "-L/opt/local/libexec/openssl3/lib -L/opt/local/lib -Wl,-headerpad_max_install_names"
      CMAKE_MODULE_PATH: "/opt/local/share/cmake/Modules"
      CMAKE_OSX_ARCHITECTURES: "ppc"
      CMAKE_OSX_DEPLOYMENT_TARGET: "10.6"
      CMAKE_OSX_SYSROOT: "/"
      CMAKE_WARN_DEPRECATED: "FALSE"
    buildResult:
      variable: "HAVE_NETINET6_IPSEC_H"
      cached: true
      stdout: |
        Change Dir: '/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_net_openiked/openiked/work/build/CMakeFiles/CMakeScratch/TryCompile-wIY0xP'
        
        Run Build Command(s): /opt/local/bin/cmake -E env VERBOSE=1 /usr/bin/make -f Makefile cmTC_17b79/fast
        /usr/bin/make  -f CMakeFiles/cmTC_17b79.dir/build.make CMakeFiles/cmTC_17b79.dir/build
        Building C object CMakeFiles/cmTC_17b79.dir/HAVE_NETINET6_IPSEC_H.c.o
        /opt/local/bin/gcc-mp-14   -pipe -I/opt/local/libexec/openssl3/include -Os -DNDEBUG -I/opt/local/libexec/openssl3/include -isystem/opt/local/include  -arch ppc -mmacosx-version-min=10.6 -o CMakeFiles/cmTC_17b79.dir/HAVE_NETINET6_IPSEC_H.c.o -c /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_net_openiked/openiked/work/build/CMakeFiles/CMakeScratch/TryCompile-wIY0xP/HAVE_NETINET6_IPSEC_H.c
        In file included from /usr/include/netinet6/ipsec.h:42,
                         from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_net_openiked/openiked/work/build/CMakeFiles/CMakeScratch/TryCompile-wIY0xP/HAVE_NETINET6_IPSEC_H.c:2:
        /usr/include/net/pfkeyv2.h:109:3: error: unknown type name 'u_int8_t'
          109 |   u_int8_t sadb_msg_version;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:110:3: error: unknown type name 'u_int8_t'
          110 |   u_int8_t sadb_msg_type;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:111:3: error: unknown type name 'u_int8_t'
          111 |   u_int8_t sadb_msg_errno;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:112:3: error: unknown type name 'u_int8_t'
          112 |   u_int8_t sadb_msg_satype;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:113:3: error: unknown type name 'u_int16_t'
          113 |   u_int16_t sadb_msg_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:114:3: error: unknown type name 'u_int16_t'
          114 |   u_int16_t sadb_msg_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:115:3: error: unknown type name 'u_int32_t'
          115 |   u_int32_t sadb_msg_seq;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:116:3: error: unknown type name 'u_int32_t'
          116 |   u_int32_t sadb_msg_pid;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:120:3: error: unknown type name 'u_int16_t'
          120 |   u_int16_t sadb_ext_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:121:3: error: unknown type name 'u_int16_t'
          121 |   u_int16_t sadb_ext_type;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:125:3: error: unknown type name 'u_int16_t'
          125 |   u_int16_t sadb_sa_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:126:3: error: unknown type name 'u_int16_t'
          126 |   u_int16_t sadb_sa_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:127:3: error: unknown type name 'u_int32_t'
          127 |   u_int32_t sadb_sa_spi;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:128:3: error: unknown type name 'u_int8_t'
          128 |   u_int8_t sadb_sa_replay;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:129:3: error: unknown type name 'u_int8_t'
          129 |   u_int8_t sadb_sa_state;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:130:3: error: unknown type name 'u_int8_t'
          130 |   u_int8_t sadb_sa_auth;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:131:3: error: unknown type name 'u_int8_t'
          131 |   u_int8_t sadb_sa_encrypt;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:132:3: error: unknown type name 'u_int32_t'
          132 |   u_int32_t sadb_sa_flags;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:137:3: error: unknown type name 'u_int16_t'
          137 |   u_int16_t sadb_lifetime_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:138:3: error: unknown type name 'u_int16_t'
          138 |   u_int16_t sadb_lifetime_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:139:3: error: unknown type name 'u_int32_t'
          139 |   u_int32_t sadb_lifetime_allocations;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:140:3: error: unknown type name 'u_int64_t'
          140 |   u_int64_t sadb_lifetime_bytes;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:141:3: error: unknown type name 'u_int64_t'
          141 |   u_int64_t sadb_lifetime_addtime;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:142:3: error: unknown type name 'u_int64_t'
          142 |   u_int64_t sadb_lifetime_usetime;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:146:3: error: unknown type name 'u_int16_t'
          146 |   u_int16_t sadb_address_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:147:3: error: unknown type name 'u_int16_t'
          147 |   u_int16_t sadb_address_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:148:3: error: unknown type name 'u_int8_t'
          148 |   u_int8_t sadb_address_proto;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:149:3: error: unknown type name 'u_int8_t'
          149 |   u_int8_t sadb_address_prefixlen;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:150:3: error: unknown type name 'u_int16_t'
          150 |   u_int16_t sadb_address_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:154:3: error: unknown type name 'u_int16_t'
          154 |   u_int16_t sadb_key_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:155:3: error: unknown type name 'u_int16_t'
          155 |   u_int16_t sadb_key_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:156:3: error: unknown type name 'u_int16_t'
          156 |   u_int16_t sadb_key_bits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:157:3: error: unknown type name 'u_int16_t'
          157 |   u_int16_t sadb_key_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:161:3: error: unknown type name 'u_int16_t'
          161 |   u_int16_t sadb_ident_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:162:3: error: unknown type name 'u_int16_t'
          162 |   u_int16_t sadb_ident_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:163:3: error: unknown type name 'u_int16_t'
          163 |   u_int16_t sadb_ident_type;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:164:3: error: unknown type name 'u_int16_t'
          164 |   u_int16_t sadb_ident_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:165:3: error: unknown type name 'u_int64_t'
          165 |   u_int64_t sadb_ident_id;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:169:3: error: unknown type name 'u_int16_t'
          169 |   u_int16_t sadb_sens_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:170:3: error: unknown type name 'u_int16_t'
          170 |   u_int16_t sadb_sens_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:171:3: error: unknown type name 'u_int32_t'
          171 |   u_int32_t sadb_sens_dpd;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:172:3: error: unknown type name 'u_int8_t'
          172 |   u_int8_t sadb_sens_sens_level;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:173:3: error: unknown type name 'u_int8_t'
          173 |   u_int8_t sadb_sens_sens_len;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:174:3: error: unknown type name 'u_int8_t'
          174 |   u_int8_t sadb_sens_integ_level;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:175:3: error: unknown type name 'u_int8_t'
          175 |   u_int8_t sadb_sens_integ_len;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:176:3: error: unknown type name 'u_int32_t'
          176 |   u_int32_t sadb_sens_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:180:3: error: unknown type name 'u_int16_t'
          180 |   u_int16_t sadb_prop_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:181:3: error: unknown type name 'u_int16_t'
          181 |   u_int16_t sadb_prop_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:182:3: error: unknown type name 'u_int8_t'
          182 |   u_int8_t sadb_prop_replay;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:183:3: error: unknown type name 'u_int8_t'
          183 |   u_int8_t sadb_prop_reserved[3];
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:187:3: error: unknown type name 'u_int8_t'
          187 |   u_int8_t sadb_comb_auth;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:188:3: error: unknown type name 'u_int8_t'
          188 |   u_int8_t sadb_comb_encrypt;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:189:3: error: unknown type name 'u_int16_t'
          189 |   u_int16_t sadb_comb_flags;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:190:3: error: unknown type name 'u_int16_t'
          190 |   u_int16_t sadb_comb_auth_minbits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:191:3: error: unknown type name 'u_int16_t'
          191 |   u_int16_t sadb_comb_auth_maxbits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:192:3: error: unknown type name 'u_int16_t'
          192 |   u_int16_t sadb_comb_encrypt_minbits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:193:3: error: unknown type name 'u_int16_t'
          193 |   u_int16_t sadb_comb_encrypt_maxbits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:194:3: error: unknown type name 'u_int32_t'
          194 |   u_int32_t sadb_comb_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:195:3: error: unknown type name 'u_int32_t'
          195 |   u_int32_t sadb_comb_soft_allocations;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:196:3: error: unknown type name 'u_int32_t'
          196 |   u_int32_t sadb_comb_hard_allocations;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:197:3: error: unknown type name 'u_int64_t'
          197 |   u_int64_t sadb_comb_soft_bytes;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:198:3: error: unknown type name 'u_int64_t'
          198 |   u_int64_t sadb_comb_hard_bytes;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:199:3: error: unknown type name 'u_int64_t'
          199 |   u_int64_t sadb_comb_soft_addtime;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:200:3: error: unknown type name 'u_int64_t'
          200 |   u_int64_t sadb_comb_hard_addtime;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:201:3: error: unknown type name 'u_int64_t'
          201 |   u_int64_t sadb_comb_soft_usetime;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:202:3: error: unknown type name 'u_int64_t'
          202 |   u_int64_t sadb_comb_hard_usetime;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:206:3: error: unknown type name 'u_int16_t'
          206 |   u_int16_t sadb_supported_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:207:3: error: unknown type name 'u_int16_t'
          207 |   u_int16_t sadb_supported_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:208:3: error: unknown type name 'u_int32_t'
          208 |   u_int32_t sadb_supported_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:212:3: error: unknown type name 'u_int8_t'
          212 |   u_int8_t sadb_alg_id;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:213:3: error: unknown type name 'u_int8_t'
          213 |   u_int8_t sadb_alg_ivlen;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:214:3: error: unknown type name 'u_int16_t'
          214 |   u_int16_t sadb_alg_minbits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:215:3: error: unknown type name 'u_int16_t'
          215 |   u_int16_t sadb_alg_maxbits;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:216:3: error: unknown type name 'u_int16_t'
          216 |   u_int16_t sadb_alg_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:220:3: error: unknown type name 'u_int16_t'
          220 |   u_int16_t sadb_spirange_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:221:3: error: unknown type name 'u_int16_t'
          221 |   u_int16_t sadb_spirange_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:222:3: error: unknown type name 'u_int32_t'
          222 |   u_int32_t sadb_spirange_min;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:223:3: error: unknown type name 'u_int32_t'
          223 |   u_int32_t sadb_spirange_max;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:224:3: error: unknown type name 'u_int32_t'
          224 |   u_int32_t sadb_spirange_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:228:3: error: unknown type name 'u_int16_t'
          228 |   u_int16_t sadb_x_kmprivate_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:229:3: error: unknown type name 'u_int16_t'
          229 |   u_int16_t sadb_x_kmprivate_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:230:3: error: unknown type name 'u_int32_t'
          230 |   u_int32_t sadb_x_kmprivate_reserved;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:240:3: error: unknown type name 'u_int16_t'
          240 |   u_int16_t sadb_x_sa2_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:241:3: error: unknown type name 'u_int16_t'
          241 |   u_int16_t sadb_x_sa2_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:242:3: error: unknown type name 'u_int8_t'
          242 |   u_int8_t sadb_x_sa2_mode;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:243:3: error: unknown type name 'u_int8_t'
          243 |   u_int8_t sadb_x_sa2_reserved1;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:244:3: error: unknown type name 'u_int16_t'
          244 |   u_int16_t sadb_x_sa2_reserved2;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:245:3: error: unknown type name 'u_int32_t'
          245 |   u_int32_t sadb_x_sa2_sequence;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:246:3: error: unknown type name 'u_int32_t'
          246 |   u_int32_t sadb_x_sa2_reqid;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:252:3: error: unknown type name 'u_int16_t'
          252 |   u_int16_t sadb_x_policy_len;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:253:3: error: unknown type name 'u_int16_t'
          253 |   u_int16_t sadb_x_policy_exttype;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:254:3: error: unknown type name 'u_int16_t'
          254 |   u_int16_t sadb_x_policy_type;         /* See policy type of ipsec.h */
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:255:3: error: unknown type name 'u_int8_t'
          255 |   u_int8_t sadb_x_policy_dir;           /* direction, see ipsec.h */
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:256:3: error: unknown type name 'u_int8_t'
          256 |   u_int8_t sadb_x_policy_reserved;
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:257:3: error: unknown type name 'u_int32_t'
          257 |   u_int32_t sadb_x_policy_id;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:258:3: error: unknown type name 'u_int32_t'
          258 |   u_int32_t sadb_x_policy_reserved2;
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:272:3: error: unknown type name 'u_int16_t'
          272 |   u_int16_t sadb_x_ipsecrequest_len;    /* structure length aligned to 8 bytes.
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:275:3: error: unknown type name 'u_int16_t'
          275 |   u_int16_t sadb_x_ipsecrequest_proto;  /* See ipsec.h */
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:276:3: error: unknown type name 'u_int8_t'
          276 |   u_int8_t sadb_x_ipsecrequest_mode;    /* See IPSEC_MODE_XX in ipsec.h. */
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:277:3: error: unknown type name 'u_int8_t'
          277 |   u_int8_t sadb_x_ipsecrequest_level;   /* See IPSEC_LEVEL_XX in ipsec.h */
              |   ^~~~~~~~
        /usr/include/net/pfkeyv2.h:278:3: error: unknown type name 'u_int16_t'
          278 |   u_int16_t sadb_x_ipsecrequest_reqid;  /* See ipsec.h */
              |   ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:290:9: error: unknown type name 'u_int16_t'
          290 |         u_int16_t            sadb_session_id_len;
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:291:9: error: unknown type name 'u_int16_t'
          291 |         u_int16_t            sadb_session_id_exttype;
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:295:9: error: unknown type name 'u_int64_t'
          295 |         u_int64_t            sadb_session_id_v[2];
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:299:9: error: unknown type name 'u_int32_t'
          299 |         u_int32_t            spi;               /* SPI Value, network byte order */
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:300:9: error: unknown type name 'u_int32_t'
          300 |         u_int32_t            created;           /* for lifetime */
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:305:9: error: unknown type name 'u_int16_t'
          305 |         u_int16_t            sadb_sastat_len;
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:306:9: error: unknown type name 'u_int16_t'
          306 |         u_int16_t            sadb_sastat_exttype;
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:307:9: error: unknown type name 'u_int32_t'
          307 |         u_int32_t            sadb_sastat_dir;
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:308:9: error: unknown type name 'u_int32_t'
          308 |         u_int32_t            sadb_sastat_reserved;
              |         ^~~~~~~~~
        /usr/include/net/pfkeyv2.h:309:9: error: unknown type name 'u_int32_t'
          309 |         u_int32_t            sadb_sastat_list_len;
              |         ^~~~~~~~~
        /usr/include/netinet6/ipsec.h:100:9: error: unknown type name 'u_quad_t'
          100 |         u_quad_t in_success;  /* succeeded inbound process */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:101:9: error: unknown type name 'u_quad_t'
          101 |         u_quad_t in_polvio;
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:103:9: error: unknown type name 'u_quad_t'
          103 |         u_quad_t in_nosa;     /* inbound SA is unavailable */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:104:9: error: unknown type name 'u_quad_t'
          104 |         u_quad_t in_inval;    /* inbound processing failed due to EINVAL */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:105:9: error: unknown type name 'u_quad_t'
          105 |         u_quad_t in_nomem;    /* inbound processing failed due to ENOBUFS */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:106:9: error: unknown type name 'u_quad_t'
          106 |         u_quad_t in_badspi;   /* failed getting a SPI */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:107:9: error: unknown type name 'u_quad_t'
          107 |         u_quad_t in_ahreplay; /* AH replay check failed */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:108:9: error: unknown type name 'u_quad_t'
          108 |         u_quad_t in_espreplay; /* ESP replay check failed */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:109:9: error: unknown type name 'u_quad_t'
          109 |         u_quad_t in_ahauthsucc; /* AH authentication success */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:110:9: error: unknown type name 'u_quad_t'
          110 |         u_quad_t in_ahauthfail; /* AH authentication failure */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:111:9: error: unknown type name 'u_quad_t'
          111 |         u_quad_t in_espauthsucc; /* ESP authentication success */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:112:9: error: unknown type name 'u_quad_t'
          112 |         u_quad_t in_espauthfail; /* ESP authentication failure */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:113:9: error: unknown type name 'u_quad_t'
          113 |         u_quad_t in_esphist[256];
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:114:9: error: unknown type name 'u_quad_t'
          114 |         u_quad_t in_ahhist[256];
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:115:9: error: unknown type name 'u_quad_t'
          115 |         u_quad_t in_comphist[256];
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:116:9: error: unknown type name 'u_quad_t'
          116 |         u_quad_t out_success; /* succeeded outbound process */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:117:9: error: unknown type name 'u_quad_t'
          117 |         u_quad_t out_polvio;
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:119:9: error: unknown type name 'u_quad_t'
          119 |         u_quad_t out_nosa;    /* outbound SA is unavailable */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:120:9: error: unknown type name 'u_quad_t'
          120 |         u_quad_t out_inval;   /* outbound process failed due to EINVAL */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:121:9: error: unknown type name 'u_quad_t'
          121 |         u_quad_t out_nomem;    /* inbound processing failed due to ENOBUFS */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:122:9: error: unknown type name 'u_quad_t'
          122 |         u_quad_t out_noroute; /* there is no route */
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:123:9: error: unknown type name 'u_quad_t'
          123 |         u_quad_t out_esphist[256];
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:124:9: error: unknown type name 'u_quad_t'
          124 |         u_quad_t out_ahhist[256];
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:125:9: error: unknown type name 'u_quad_t'
          125 |         u_quad_t out_comphist[256];
              |         ^~~~~~~~
        /usr/include/netinet6/ipsec.h:130:8: error: unknown type name 'caddr_t'
          130 | extern caddr_t ipsec_set_policy(char *, int);
              |        ^~~~~~~
        /usr/include/netinet6/ipsec.h:131:1: error: parameter names (without types) in function declaration [-Wdeclaration-missing-parameter-type]
          131 | extern int ipsec_get_policylen(caddr_t);
              | ^~~~~~
        /usr/include/netinet6/ipsec.h:132:40: error: expected ')' before 'char'
          132 | extern char *ipsec_dump_policy(caddr_t, char *);
              |                                        ^~~~~
              |                                        )
        make[1]: *** [CMakeFiles/cmTC_17b79.dir/HAVE_NETINET6_IPSEC_H.c.o] Error 1
        make: *** [cmTC_17b79/fast] Error 2
        
      exitCode: 2
```

Like some other headers, this one also needs `sys/types.h` to precede it.