### PR TITLE
vroute.c: include sys/socket.h on macOS

### DIFF
--- a/iked/vroute.c
+++ b/iked/vroute.c
@@ -18,6 +18,7 @@
 
 #include <sys/ioctl.h>
 
+#include <sys/socket.h>
 #include <net/if.h>
 #include <net/route.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Fixes this error:
```
In file included from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_net_openiked/openiked/work/openiked-portable-7.4/iked/vroute.c:21:
/usr/include/net/if.h:265:34: error: field 'ifru_addr' has incomplete type
  265 |                 struct  sockaddr ifru_addr;
      |                                  ^~~~~~~~~
/usr/include/net/if.h:266:34: error: field 'ifru_dstaddr' has incomplete type
  266 |                 struct  sockaddr ifru_dstaddr;
      |                                  ^~~~~~~~~~~~
/usr/include/net/if.h:267:34: error: field 'ifru_broadaddr' has incomplete type
  267 |                 struct  sockaddr ifru_broadaddr;
      |                                  ^~~~~~~~~~~~~~
/usr/include/net/if.h:308:26: error: field 'ifra_addr' has incomplete type
  308 |         struct  sockaddr ifra_addr;
      |                          ^~~~~~~~~
/usr/include/net/if.h:309:26: error: field 'ifra_broadaddr' has incomplete type
  309 |         struct  sockaddr ifra_broadaddr;
      |                          ^~~~~~~~~~~~~~
/usr/include/net/if.h:310:26: error: field 'ifra_mask' has incomplete type
  310 |         struct  sockaddr ifra_mask;
      |                          ^~~~~~~~~
/usr/include/net/if.h:393:33: error: field 'addr' has incomplete type
  393 |         struct sockaddr_storage addr;   /* in/out */
      |                                 ^~~~
/usr/include/net/if.h:394:33: error: field 'dstaddr' has incomplete type
  394 |         struct sockaddr_storage dstaddr; /* out */
      |                                 ^~~~~~~
```

Possibly can be included unconditionally, but I cannot verify that.